### PR TITLE
SnapProcessorRTOS: raise task priority by one

### DIFF
--- a/src/SnapConfig.h
+++ b/src/SnapConfig.h
@@ -63,3 +63,7 @@
 #ifndef RTOS_STACK_SIZE 
 #   define RTOS_STACK_SIZE 10 * 1024
 #endif
+
+#ifndef RTOS_TASK_PRIORITY
+#   define RTOS_TASK_PRIORITY 2
+#endif

--- a/src/api/SnapProcessorRTOS.h
+++ b/src/api/SnapProcessorRTOS.h
@@ -41,7 +41,7 @@ class SnapProcessorRTOS : public SnapProcessor {
 
  protected:
   const char *TAG = "SnapProcessorRTOS";
-  cpp_freertos::Task task{"output", RTOS_STACK_SIZE, 1, task_copy};
+  cpp_freertos::Task task{"output", RTOS_STACK_SIZE, RTOS_TASK_PRIORITY, task_copy};
   cpp_freertos::Queue size_queue{RTOS_MAX_QUEUE_ENTRY_COUNT, sizeof(size_t)};
   audio_tools::SynchronizedBufferRTOS<uint8_t> buffer{0}; // size defined in constructor
   bool task_started = false;


### PR DESCRIPTION
I propose raising the task priority of the SnapProcessorRTOS to `2`.
The Main Task is already running at priority level 1 (see: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/freertos.html#background-tasks)

Feel free to disregard this PR. This might starve the main task and have side-effects. However, I think copying real-time audio data to the peripheral warrants taking priority.

I'm tinkering around with ESPHome and there is too much going on with priority level 1. Raising the priority and setting large buffer sizes makes it almost usable (but not quite).