### PR TITLE
Apply playback factor on startup, pass Volume and recalculate ByteLimits

### DIFF
--- a/src/api/SnapOutput.h
+++ b/src/api/SnapOutput.h
@@ -76,7 +76,7 @@ class SnapOutput : public AudioInfoSupport {
   /// mute / unmute
   void setMute(bool mute) {
     is_mute = mute;
-    vol_stream.setVolume(mute ? 0 : vol);
+    vol_stream.setVolume(mute ? 0 : vol * vol_factor);
     audioWriteSilence();
   }
 
@@ -153,6 +153,7 @@ class SnapOutput : public AudioInfoSupport {
     vol_cfg.copyFrom(audio_info);
     vol_cfg.allow_boost = true;
     vol_stream.begin(vol_cfg);
+    vol_stream.setVolume(vol * vol_factor);
 
     // open final output
     out->setAudioInfo(audio_info);

--- a/src/api/SnapOutput.h
+++ b/src/api/SnapOutput.h
@@ -250,6 +250,7 @@ class SnapOutput : public AudioInfoSupport {
       setPlaybackFactor(p_snap_time_sync->getFactor());
       // replaced delay(delay_ms); with timed_stream
       timed_stream.setStartMs(delay_ms);
+      timed_stream.begin();
       is_sync_started = true;
       result = true;
     }

--- a/src/api/SnapOutput.h
+++ b/src/api/SnapOutput.h
@@ -246,6 +246,7 @@ class SnapOutput : public AudioInfoSupport {
     } else {
       // wait for the audio to become valid
       ESP_LOGI(TAG, "starting after %d ms", delay_ms);
+      setPlaybackFactor(p_snap_time_sync->getFactor());
       // replaced delay(delay_ms); with timed_stream
       timed_stream.setStartMs(delay_ms);
       is_sync_started = true;


### PR DESCRIPTION
I've made a few smaller fixes:

1. The Playback factor isn't set on startup, just after the first interval which doesn't ever happen for the Fixed version. I've added this to the initial sync.
2. The Volume isn't set passed at startup. Well it is, but it gets overwritten by the default vol_cfg
3. Also I think the mute function was missing a conversion
4. I've included a workaround for https://github.com/pschatzmann/arduino-audio-tools/pull/1407 in timed_stream. I can drop that commit if you like.

Regarding the TimedStream: There is still something wrong. It still doesn't make a difference what I set. I can't wrap my head around that... Is this code alright?:

https://github.com/pschatzmann/arduino-audio-tools/blob/70a927ff23fae2f0fece2da85b0a9ba51b15edf7/src/AudioTools/AudioIO.h#L277-L279

In case this returns false: Does whover writes to it actually keep the samples in buffer so we actually delay it? Or are the buffers dropped on 'false' and we start with the same data anyways?