### PR TITLE
fix(resample): function name changed in dependent package

### DIFF
--- a/src/api/SnapOutput.h
+++ b/src/api/SnapOutput.h
@@ -88,7 +88,7 @@ class SnapOutput : public AudioInfoSupport {
   /// Defines the audio output chain to the final output
   void setOutput(AudioOutput &output) {
     this->out = &output;  // final output
-    resample.setStream(output);
+    resample.setOutput(output);
     vol_stream.setStream(resample);  // adjust volume
     decoder_stream.setStream(&vol_stream);  // decode to pcm
   }


### PR DESCRIPTION
in [v0.9.8](https://github.com/pschatzmann/arduino-audio-tools) of the `arduino-audio-tools` the Resample functions were refactored, this resulted in the `setStream` being renamed `setOutput`. This took a good while to track down because it wasn't clear why the `override` was throwing an error on the `virtual` `void`.

This brings the code back into a functional state.